### PR TITLE
Issue 5074 numbers cropped in leaderboard

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/profile/achievements/AchievementsFragment.java
+++ b/app/src/main/java/fr/free/nrw/commons/profile/achievements/AchievementsFragment.java
@@ -78,8 +78,14 @@ public class AchievementsFragment extends CommonsDaggerSupportFragment {
     @BindView(R.id.images_uploaded_progressbar)
     CircleProgressBar imagesUploadedProgressbar;
 
+    @BindView(R.id.tv_uploaded_images)
+    AppCompatTextView uploadedImagesTextview;
+
     @BindView(R.id.images_used_by_wiki_progress_bar)
     CircleProgressBar imagesUsedByWikiProgressBar;
+
+    @BindView(R.id.tv_wiki_pb)
+    AppCompatTextView imagesUsedByWikiTextview;
 
     @BindView(R.id.image_reverts_progressbar)
     CircleProgressBar imageRevertsProgressbar;
@@ -366,8 +372,8 @@ public class AchievementsFragment extends CommonsDaggerSupportFragment {
             imagesUploadedProgressbar.setVisibility(View.VISIBLE);
             imagesUploadedProgressbar.setProgress
                     (100*uploadCount/levelInfo.getMaxUploadCount());
-            imagesUploadedProgressbar.setProgressTextFormatPattern
-                    (uploadCount +"/" + levelInfo.getMaxUploadCount() );
+            uploadedImagesTextview.setText
+                (uploadCount + "/" + levelInfo.getMaxUploadCount());
         }
 
     }
@@ -416,8 +422,8 @@ public class AchievementsFragment extends CommonsDaggerSupportFragment {
         thanksReceived.setText(String.valueOf(achievements.getThanksReceived()));
         imagesUsedByWikiProgressBar.setProgress
                 (100 * achievements.getUniqueUsedImages() / levelInfo.getMaxUniqueImages());
-        imagesUsedByWikiProgressBar.setProgressTextFormatPattern
-                (achievements.getUniqueUsedImages() + "/" + levelInfo.getMaxUniqueImages());
+        imagesUsedByWikiTextview.setText
+            (achievements.getUniqueUsedImages() + "/" + levelInfo.getMaxUniqueImages());
         imagesFeatured.setText(String.valueOf(achievements.getFeaturedImages()));
         tvQualityImages.setText(String.valueOf(achievements.getQualityImages()));
         String levelUpInfoString = getString(R.string.level).toUpperCase();

--- a/app/src/main/java/fr/free/nrw/commons/upload/UploadMediaDetailAdapter.java
+++ b/app/src/main/java/fr/free/nrw/commons/upload/UploadMediaDetailAdapter.java
@@ -1,7 +1,6 @@
 package fr.free.nrw.commons.upload;
 
 import android.app.Dialog;
-import android.content.Intent;
 import android.text.Editable;
 import android.text.InputFilter;
 import android.text.TextUtils;
@@ -23,7 +22,6 @@ import butterknife.BindView;
 import butterknife.ButterKnife;
 import com.google.android.material.textfield.TextInputLayout;
 import fr.free.nrw.commons.R;
-import fr.free.nrw.commons.contributions.MainActivity;
 import fr.free.nrw.commons.recentlanguages.Language;
 import fr.free.nrw.commons.recentlanguages.RecentLanguagesAdapter;
 import fr.free.nrw.commons.recentlanguages.RecentLanguagesDao;
@@ -32,10 +30,8 @@ import fr.free.nrw.commons.utils.AbstractTextWatcher;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Locale;
 import java.util.Objects;
 import java.util.regex.Pattern;
-import javax.inject.Inject;
 import timber.log.Timber;
 
 public class UploadMediaDetailAdapter extends RecyclerView.Adapter<UploadMediaDetailAdapter.ViewHolder> {
@@ -198,7 +194,8 @@ public class UploadMediaDetailAdapter extends RecyclerView.Adapter<UploadMediaDe
 
             removeButton.setOnClickListener(v -> removeDescription(uploadMediaDetail, position));
             captionListener = new AbstractTextWatcher(
-                captionText -> uploadMediaDetails.get(position).setCaptionText(convertIdeographicSpaceToLatinSpace(removeTrailingWhitespace(captionText))));
+                captionText -> uploadMediaDetails.get(position).setCaptionText(convertIdeographicSpaceToLatinSpace(
+                    removeLeadingAndTrailingWhitespace(captionText))));
             descriptionListener = new AbstractTextWatcher(
                 descriptionText -> uploadMediaDetails.get(position).setDescriptionText(descriptionText));
             captionItemEditText.addTextChangedListener(captionListener);
@@ -421,28 +418,35 @@ public class UploadMediaDetailAdapter extends RecyclerView.Adapter<UploadMediaDe
         }
 
         /**
-         * Checks if the source string contains trailing whitespace
+         * Removes any leading and trailing whitespace from the source text.
          * @param source input string
-         * @return true if contains trailing whitespace and false otherwise
+         * @return a string without leading and trailing whitespace
          */
-        public Boolean checkTrailingWhitespace(String source) {
-            int len = source.length();
-            if (len == 0) {
-                return false;
+        public String removeLeadingAndTrailingWhitespace(String source) {
+            // This method can be replaced with the inbuilt String::strip when updated to JDK 11.
+            // Note that String::trim does not adequately remove all whitespace chars.
+            int firstNonWhitespaceIndex = 0;
+            while (firstNonWhitespaceIndex < source.length()) {
+                if (Character.isWhitespace(source.charAt(firstNonWhitespaceIndex))) {
+                    firstNonWhitespaceIndex++;
+                } else {
+                    break;
+                }
             }
-            return Character.isWhitespace(source.charAt(len - 1));
-        }
+            if (firstNonWhitespaceIndex == source.length()) {
+                return "";
+            }
 
-        /**
-         * Removes any trailing whitespace from the source text.
-         * @param source input string
-         * @return a string without trailing whitespace
-         */
-        public String removeTrailingWhitespace(String source) {
-            while (checkTrailingWhitespace(source)) {
-                source = source.substring(0, source.length() - 1);
+            int lastNonWhitespaceIndex = source.length() - 1;
+            while (lastNonWhitespaceIndex > firstNonWhitespaceIndex) {
+                if (Character.isWhitespace(source.charAt(lastNonWhitespaceIndex))) {
+                    lastNonWhitespaceIndex--;
+                } else {
+                    break;
+                }
             }
-            return source;
+
+            return source.substring(firstNonWhitespaceIndex, lastNonWhitespaceIndex + 1);
         }
 
         /**

--- a/app/src/main/res/layout/fragment_achievements.xml
+++ b/app/src/main/res/layout/fragment_achievements.xml
@@ -128,25 +128,48 @@
 
             </LinearLayout>
 
-
-
-            <com.dinuscxj.progressbar.CircleProgressBar
+            <FrameLayout
               android:layout_width="@dimen/dimen_40"
               android:layout_height="@dimen/dimen_40"
-              android:layout_alignParentRight="true"
               android:layout_alignParentEnd="true"
-              android:layout_marginEnd="@dimen/large_gap"
-              android:layout_marginRight="@dimen/large_gap"
-              android:id="@+id/images_uploaded_progressbar"
-              android:progress="50"
-              app:progress_text_size="@dimen/progressbar_text"
-              app:progress_end_color="#8C8B98"
-              app:progress_start_color="#3A3381"
-              app:progress_stroke_width="@dimen/progressbar_stroke"
-              app:progress_text_format_pattern="573/110"
-              android:visibility="gone"
-              app:progress_text_color="@color/secondaryColor"
-              app:style="solid_line" />
+              android:layout_alignParentRight="true"
+              android:layout_marginEnd="32dp"
+              android:layout_marginRight="32dp">
+
+              <com.dinuscxj.progressbar.CircleProgressBar
+                android:layout_width="@dimen/dimen_40"
+                android:layout_height="@dimen/dimen_40"
+                android:layout_alignParentRight="true"
+                android:layout_alignParentEnd="true"
+                android:layout_marginEnd="@dimen/large_gap"
+                android:layout_marginRight="@dimen/large_gap"
+                android:id="@+id/images_uploaded_progressbar"
+                android:progress="50"
+                app:progress_text_size="@dimen/progressbar_text"
+                app:progress_end_color="#8C8B98"
+                app:progress_start_color="#3A3381"
+                app:progress_stroke_width="@dimen/progressbar_stroke"
+                app:progress_text_format_pattern=""
+                android:visibility="gone"
+                app:progress_text_color="@color/secondaryColor"
+                app:style="solid_line" />
+
+              <androidx.appcompat.widget.AppCompatTextView
+                android:id="@+id/tv_uploaded_images"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:padding="@dimen/progressbar_padding"
+                android:gravity="center"
+                android:maxLines="1"
+                android:textColor="@color/secondaryColor"
+                app:autoSizeMaxTextSize="@dimen/progressbar_text"
+                app:autoSizeMinTextSize="2sp"
+                app:autoSizeStepGranularity="1sp"
+                app:autoSizeTextType="uniform" />
+
+            </FrameLayout>
+
+
 
           </RelativeLayout>
 
@@ -267,23 +290,46 @@
 
             </LinearLayout>
 
-            <com.dinuscxj.progressbar.CircleProgressBar
+            <FrameLayout
               android:layout_width="@dimen/dimen_40"
               android:layout_height="@dimen/dimen_40"
-              android:layout_alignParentRight="true"
               android:layout_alignParentEnd="true"
-              android:layout_marginRight="@dimen/large_gap"
-              android:layout_marginEnd="@dimen/large_gap"
-              android:progress="50"
-              app:progress_text_size="@dimen/progressbar_text"
-              android:id="@+id/images_used_by_wiki_progress_bar"
-              app:progress_end_color="#8C8B98"
-              app:progress_start_color="#3A3381"
-              app:progress_stroke_width="2.5dp"
-              android:visibility="gone"
-              app:progress_text_color="@color/secondaryColor"
-              app:progress_text_format_pattern="12/24"
-              app:style="solid_line" />
+              android:layout_alignParentRight="true"
+              android:layout_marginEnd="32dp"
+              android:layout_marginRight="32dp">
+
+              <com.dinuscxj.progressbar.CircleProgressBar
+                android:layout_width="@dimen/dimen_40"
+                android:layout_height="@dimen/dimen_40"
+                android:layout_alignParentRight="true"
+                android:layout_alignParentEnd="true"
+                android:layout_marginRight="@dimen/large_gap"
+                android:layout_marginEnd="@dimen/large_gap"
+                android:progress="50"
+                app:progress_text_size="@dimen/progressbar_text"
+                android:id="@+id/images_used_by_wiki_progress_bar"
+                app:progress_end_color="#8C8B98"
+                app:progress_start_color="#3A3381"
+                app:progress_stroke_width="2.5dp"
+                android:visibility="gone"
+                app:progress_text_color="@color/secondaryColor"
+                app:progress_text_format_pattern=""
+                app:style="solid_line" />
+
+              <androidx.appcompat.widget.AppCompatTextView
+                android:id="@+id/tv_wiki_pb"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:padding="@dimen/progressbar_padding"
+                android:gravity="center"
+                android:maxLines="1"
+                android:textColor="@color/secondaryColor"
+                app:autoSizeMaxTextSize="@dimen/progressbar_text"
+                app:autoSizeMinTextSize="2sp"
+                app:autoSizeStepGranularity="1sp"
+                app:autoSizeTextType="uniform" />
+
+            </FrameLayout>
 
           </RelativeLayout>
 

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -32,6 +32,7 @@
     <dimen name="very_large_height">240dp</dimen>
     <dimen name="fragment_height">48dp</dimen>
     <dimen name="filter_padding">15dp</dimen>
+    <dimen name="progressbar_padding">3.5dp</dimen>
 
     <!-- Component sizes -->
     <dimen name="overflow_icon_dimen">56dp</dimen>
@@ -52,7 +53,7 @@
     <dimen name="first_fab">15dp</dimen>
     <dimen name="second_fab">25dp</dimen>
     <dimen name="subtitle_text">12sp</dimen>
-    <dimen name="progressbar_text">9dp</dimen>
+    <dimen name="progressbar_text">9sp</dimen>
 
     <!-- App widget margin -->
     <dimen name="widget_margin">0dp</dimen>

--- a/app/src/test/kotlin/fr/free/nrw/commons/upload/UploadMediaDetailAdapterUnitTest.kt
+++ b/app/src/test/kotlin/fr/free/nrw/commons/upload/UploadMediaDetailAdapterUnitTest.kt
@@ -248,39 +248,39 @@ class UploadMediaDetailAdapterUnitTest {
     }
 
     @Test
-    fun testRemoveTrailingWhitespace() {
+    fun testRemoveLeadingAndTrailingWhitespace() {
         // empty space
-        val test1 = "test  "
+        val test1 = "  test  "
         val expected1 = "test"
-        Assert.assertTrue(viewHolder.checkTrailingWhitespace(test1));
-        Assert.assertEquals(expected1, viewHolder.removeTrailingWhitespace(test1))
+        Assert.assertEquals(expected1, viewHolder.removeLeadingAndTrailingWhitespace(test1))
 
-        val test2 = "test test "
+        val test2 = "  test test "
         val expected2 = "test test"
-        Assert.assertTrue(viewHolder.checkTrailingWhitespace(test2));
-        Assert.assertEquals(expected2, viewHolder.removeTrailingWhitespace(test2))
+        Assert.assertEquals(expected2, viewHolder.removeLeadingAndTrailingWhitespace(test2))
 
         // No whitespace
         val test3 = "No trailing space";
         val expected3 = "No trailing space";
-        Assert.assertFalse(viewHolder.checkTrailingWhitespace(test3))
-        Assert.assertEquals(expected3, viewHolder.removeTrailingWhitespace(test3))
+        Assert.assertEquals(expected3, viewHolder.removeLeadingAndTrailingWhitespace(test3))
+
+        // blank string
+        val test4 = " \r \t  "
+        val expected4 = "";
+        Assert.assertEquals(expected4, viewHolder.removeLeadingAndTrailingWhitespace(test4))
     }
 
     @Test
-    fun testRemoveTrailingInstanceTab() {
-        val test = "test\t"
+    fun testRemoveLeadingAndTrailingInstanceTab() {
+        val test = "\ttest\t"
         val expected = "test"
-        Assert.assertTrue(viewHolder.checkTrailingWhitespace(test));
-        Assert.assertEquals(expected, viewHolder.removeTrailingWhitespace(test))
+        Assert.assertEquals(expected, viewHolder.removeLeadingAndTrailingWhitespace(test))
     }
 
     @Test
-    fun testRemoveTrailingCarriageReturn() {
-        val test = "test\r"
+    fun testRemoveLeadingAndTrailingCarriageReturn() {
+        val test = "\rtest\r"
         val expected = "test"
-        Assert.assertTrue(viewHolder.checkTrailingWhitespace(test));
-        Assert.assertEquals(expected, viewHolder.removeTrailingWhitespace(test))
+        Assert.assertEquals(expected, viewHolder.removeLeadingAndTrailingWhitespace(test))
     }
 
     @Test
@@ -289,9 +289,8 @@ class UploadMediaDetailAdapterUnitTest {
         val expected1 = "テスト テスト"
         Assert.assertEquals(expected1, viewHolder.convertIdeographicSpaceToLatinSpace(test1));
 
-        val test2 = "テスト　\r　\t　"
+        val test2 = "　\r　\t　テスト　\r　\t　"
         val expected2 = "テスト"
-        Assert.assertTrue(viewHolder.checkTrailingWhitespace(test2));
-        Assert.assertEquals(expected2, viewHolder.removeTrailingWhitespace(test2))
+        Assert.assertEquals(expected2, viewHolder.removeLeadingAndTrailingWhitespace(test2))
     }
 }


### PR DESCRIPTION
**Description (required)**

Fixes #5074 

What changes did you make and why?

Fix without indentation changes:

Enabled auto-scaling of text

The numbers in the Achievements fragment are getting cropped as the app is currently using a hard-coded text size value of `9dp` and the text is of the form "xxx/xxx", that is, the circular progress bar can accommodate at most 6 digits and one '/' as of now. Increasing the size of the progress bar might disturb the nearby elements and so, I enabled auto-scaling of the text.

For defining the UI, Commons makes use of the dependency: com.dinuscxj:circleprogressbar:1.1.1 (Available [here](https://github.com/dinuscxj/CircleProgressBar.git)). 

Since this library does not handle larger numbers even in the latest version, they get cropped in the Achievements fragment. Even though we can programatically scale the text size, a more reliable method is to make use of the [official Android UI guide for autoscaling text](https://developer.android.com/develop/ui/views/text-and-emoji/autosizing-textview). Modifying the library might introduce an additional maintenance overhead for the app and so, I added a frame layout to make use of the official auto-sizeable TextView. Since the circular progress bar takes up a very small portion of the activity, the GPU considerations are negligible here. 

I also changed the unit for progress bar text size from`dp` to `sp` (for [text scaling](https://support.google.com/accessibility/android/answer/12159181?hl=en)) in the `dimens` file as this dimension would not impact any other component except the fix. 

**Tests performed (required)**

Tested ProdDebug on Redmi 5A with API level 26.

**Screenshots (for UI changes only)**

Since I haven't uploaded many pictures on the Commons app, I cannot reproduce the issue directly. However, this is how the XML design shows changes in Android Studio on adding large numbers:

![achievements](https://user-images.githubusercontent.com/83745993/218317838-f4ffdb7e-e1d6-49dc-b699-b5b2383fbe88.png)